### PR TITLE
[EIC-1003]: header title & redirect url returned from .env

### DIFF
--- a/client/components/common/nav-header.vue
+++ b/client/components/common/nav-header.vue
@@ -22,7 +22,7 @@
         v-toolbar.nav-header-inner(color='black', dark, flat, :class='$vuetify.rtl ? `pr-3` : `pl-3`')
           v-avatar(tile, size='34', @click='goHome')
             v-img.org-logo(:src='logoUrl')
-          //- v-menu(open-on-hover, offset-y, bottom, left, min-width='250', transition='slide-y-transition')
+             //- v-menu(open-on-hover, offset-y, bottom, left, min-width='250', transition='slide-y-transition')
           //-   template(v-slot:activator='{ on }')
           //-     v-app-bar-nav-icon.btn-animate-app(v-on='on', :class='$vuetify.rtl ? `mx-0` : ``')
           //-       v-icon mdi-menu
@@ -43,7 +43,7 @@
           //-       v-list-item-content
           //-         v-list-item-title.body-2.grey--text.text--ligten-2 {{$t('common:header.imagesFiles')}}
           //-         v-list-item-subtitle.overline.grey--text.text--lighten-2 Coming soon
-          v-toolbar-title(:class='{ "mx-3": $vuetify.breakpoint.mdAndUp, "mx-1": $vuetify.breakpoint.smAndDown }')
+          v-toolbar-title(:class='{ "mx-3": $vuetify.breakpoint.mdAndUp, "mx-1": $vuetify.breakpoint.smAndDown }', @click='goToLiquidCore')
             span.subheading {{title}}
       v-flex(md4, v-if='$vuetify.breakpoint.mdAndUp')
         v-toolbar.nav-header-inner(color='black', dark, flat)
@@ -297,7 +297,9 @@ export default {
     searchRestrictLocale: sync('site/searchRestrictLocale'),
     searchRestrictPath: sync('site/searchRestrictPath'),
     isLoading: get('isLoading'),
-    title: get('site/title'),
+    title() {
+      return process.env.VUE_APP_LIQUID_TITLE || this.$store.get('site/title')
+    },
     logoUrl: get('site/logoUrl'),
     path: get('page/path'),
     locale: get('page/locale'),
@@ -477,6 +479,9 @@ export default {
     },
     goHome () {
       window.location.assign('/')
+    },
+    goToLiquidCore () {
+      window.location.assign(process.env.VUE_APP_LIQUID_CORE_URL || '/')
     }
   }
 }
@@ -499,7 +504,8 @@ export default {
     }
   }
 
-  .org-logo {
+  .org-logo,
+  .subheading {
     cursor: pointer;
   }
 

--- a/dev/webpack/webpack.dev.js
+++ b/dev/webpack/webpack.dev.js
@@ -16,6 +16,7 @@ const WebpackBarPlugin = require('webpackbar')
 const babelConfig = fs.readJsonSync(path.join(process.cwd(), '.babelrc'))
 const cacheDir = '.webpack-cache/cache'
 const babelDir = path.join(process.cwd(), '.webpack-cache/babel')
+const DotenvWebpack = require('dotenv-webpack')
 
 process.noDeprecation = true
 
@@ -184,6 +185,7 @@ module.exports = {
     ]
   },
   plugins: [
+    new DotenvWebpack(),
     new VueLoaderPlugin(),
     new VuetifyLoaderPlugin(),
     new MomentTimezoneDataPlugin({

--- a/dev/webpack/webpack.prod.js
+++ b/dev/webpack/webpack.prod.js
@@ -21,6 +21,7 @@ const now = Math.round(Date.now() / 1000)
 const babelConfig = fs.readJsonSync(path.join(process.cwd(), '.babelrc'))
 const cacheDir = '.webpack-cache/cache'
 const babelDir = path.join(process.cwd(), '.webpack-cache/babel')
+const DotenvWebpack = require('dotenv-webpack')
 
 process.noDeprecation = true
 
@@ -190,6 +191,7 @@ module.exports = {
     ]
   },
   plugins: [
+    new DotenvWebpack(),
     new VueLoaderPlugin(),
     new VuetifyLoaderPlugin(),
     new webpack.BannerPlugin('Wiki.js - wiki.js.org - Licensed under AGPL'),

--- a/package.json
+++ b/package.json
@@ -239,6 +239,7 @@
     "cssnano": "4.1.10",
     "cypress": "5.3.0",
     "d3": "6.2.0",
+    "dotenv-webpack": "8.0.1",
     "duplicate-package-checker-webpack-plugin": "3.0.0",
     "epic-spinners": "1.1.0",
     "eslint": "7.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8625,6 +8625,25 @@ dot-prop@^4.1.1:
   dependencies:
     is-obj "^1.0.0"
 
+dotenv-defaults@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz#6b3ec2e4319aafb70940abda72d3856770ee77ac"
+  integrity sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==
+  dependencies:
+    dotenv "^8.2.0"
+
+dotenv-webpack@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-8.0.1.tgz#6656550460a8076fab20e5ac2eac867e72478645"
+  integrity sha512-CdrgfhZOnx4uB18SgaoP9XHRN2v48BbjuXQsZY5ixs5A8579NxQkmMxRtI7aTwSiSQcM2ao12Fdu+L3ZS3bG4w==
+  dependencies:
+    dotenv-defaults "^2.0.2"
+
+dotenv@^8.2.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
+  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
+
 dotize@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/dotize/-/dotize-0.3.0.tgz#b7a5c46835f6bd4087731354308f0d160dbceeac"


### PR DESCRIPTION
closes https://github.com/CRJI/EIC/issues/1003


1. Installed the required `dotenv-webpack` package and included it as plugin in the webpack configuration
2. Header Title & redirect url are now read from `process.env` with a fallback to default values.

When setting the .env variables, please note the `VUE_APP_` prefix, which is mandatory for custom environment variables in Vue applications.